### PR TITLE
Hotfix on add wrong path to input file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,10 @@ export default {
 		} else {
 
 			helpers.readFile(input, (err, data) => {
-        if (err) {
-          console.error(err);
-          process.exit();
-        }
+				if (err) {
+					console.error(err);
+					process.exit();
+				}
 				let styleSheet = this.handleRulesAndReturnCSSJSON(data);
 				helpers.outputReactFriendlyStyle(styleSheet, output, prettyPrint)
 			});

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ export default {
 		} else {
 
 			helpers.readFile(input, (err, data) => {
+        if (err) {
+          console.error(err);
+          process.exit();
+        }
 				let styleSheet = this.handleRulesAndReturnCSSJSON(data);
 				helpers.outputReactFriendlyStyle(styleSheet, output, prettyPrint)
 			});


### PR DESCRIPTION
node_modules/react-native-css/build/index.js:266
		return string.replace(/\r?\n|\r/g, "");
		             ^

TypeError: Cannot read property 'replace' of undefined