### PR TITLE
Use writeFileSync and rebuild

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,8 +2,8 @@
 root = true
 
 [*]
-indent_style = tab
-indent_size = 4
+indent_style = space
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/build/index.js
+++ b/build/index.js
@@ -68,8 +68,16 @@ var ReactNativeCss = (function () {
   }, {
     key: 'toJSS',
     value: function toJSS(stylesheetString) {
+      var directions = ['top', 'right', 'bottom', 'left'];
       var changeArr = ['margin', 'padding'];
-      var numberize = ['width', 'font-size'];
+      var numberize = ['width', 'height', 'font-size', 'line-height', 'border-radius', 'border-width'].concat(directions);
+
+      directions.forEach(function (dir) {
+        numberize.push('border-' + dir + '-width');
+        changeArr.forEach(function (prop) {
+          numberize.push(prop + '-' + dir);
+        });
+      });
 
       // CSS properties that are not supported by React Native
       // The list of supported properties is at https://facebook.github.io/react-native/docs/style.html#supported-properties
@@ -127,7 +135,7 @@ var ReactNativeCss = (function () {
                     baseDeclaration = {
                       type: 'description'
                     };
-                    values = value.replace(/px|\s*/g, '').split(',');
+                    values = value.replace(/px/g, '').split(/[\s,]+/);
 
                     values.forEach(function (value, index, arr) {
                       arr[index] = parseInt(value);

--- a/build/utils.js
+++ b/build/utils.js
@@ -22,13 +22,12 @@ var Utils = (function () {
   _createClass(Utils, null, [{
     key: "arrayContains",
     value: function arrayContains(value, arr) {
-      var flag = false;
       for (var i = 0; i < arr.length; i++) {
         if (value === arr[i]) {
           return true;
         }
       }
-      return flag;
+      return false;
     }
   }, {
     key: "clean",
@@ -44,10 +43,10 @@ var Utils = (function () {
     key: "outputReactFriendlyStyle",
     value: function outputReactFriendlyStyle(style, outputFile, prettyPrint) {
       var indentation = prettyPrint ? 4 : 0;
-      var wstream = _fs2["default"].createWriteStream(outputFile);
       var output = JSON.stringify(style, null, indentation);
-      wstream.write("module.exports = require('react-native').StyleSheet.create(" + output + ");");
-      wstream.end();
+
+      // Write to file
+      _fs2["default"].writeFileSync(outputFile, "module.exports = require('react-native').StyleSheet.create(" + output + ");");
       return output;
     }
   }, {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default class ReactNativeCss {
           process.exit();
         }
         let styleSheet = this.toJSS(data);
-        utils.outputReactFriendlyStyle(styleSheet, output, this.prettyPrint);
+        utils.outputReactFriendlyStyle(styleSheet, output, prettyPrint);
 
         if(cb) {
           cb(styleSheet);
@@ -39,16 +39,16 @@ export default class ReactNativeCss {
   }
 
   toJSS(stylesheetString) {
-		const directions = ['top', 'right', 'bottom', 'left'];
+    const directions = ['top', 'right', 'bottom', 'left'];
     const changeArr = ['margin', 'padding'];
     const numberize = ['width', 'height', 'font-size', 'line-height', 'border-radius', 'border-width'].concat(directions);
 
-		directions.forEach((dir) => {
-			numberize.push(`border-${dir}-width`);
-			changeArr.forEach((prop) => {
-				numberize.push(`${prop}-${dir}`);
-			})
-		});
+    directions.forEach((dir) => {
+      numberize.push(`border-${dir}-width`);
+      changeArr.forEach((prop) => {
+        numberize.push(`${prop}-${dir}`);
+      })
+    });
 
     // CSS properties that are not supported by React Native
     // The list of supported properties is at https://facebook.github.io/react-native/docs/style.html#supported-properties

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,10 +21,13 @@ export default class Utils {
 
   static outputReactFriendlyStyle(style, outputFile, prettyPrint) {
     var indentation = prettyPrint ? 4 : 0;
-    var wstream = fs.createWriteStream(outputFile);
     var output = JSON.stringify(style, null, indentation);
-    wstream.write(`module.exports = require('react-native').StyleSheet.create(${output});`);
-    wstream.end();
+
+  	// Write to file
+  	fs.writeFileSync(
+		outputFile,
+		`module.exports = require('react-native').StyleSheet.create(${output});`
+	);
     return output;
   }
 


### PR DESCRIPTION
When writing the [grunt plugin](https://github.com/alexmick/grunt-react-native-css) for this library I ran into some issues with file writing. Switching to the more robust `writeFileSync` did the trick.

Also rebuilt the `build` files for changes from this and #27 