### PR TITLE
Adding --literal argument to generate js literal object

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Flags
 - "-i" takes a input (optional)
 - "-o" takes an output path (optional)
 - "-p" or "--pretty" - pretty print the resulting compiled output
+- "-l" or "--literal" - generates a javascript literal object without StyleSheet.create wrapper
 
 ## Screenshot
 
@@ -71,7 +72,14 @@ React-native-css will generate to the following:
 module.exports = require('react-native').StyleSheet.create(
   {"description":{"marginBottom":20,"fontSize":18,"textAlign":"center","color":"#656656"},"container":{"padding":30,"marginTop":65,"alignItems":"center"}}
   );
-```
+```  
+You can make use of --literal argument and instead it will generate:
+``` javascript
+// style.js
+module.exports = {
+  "description":{"marginBottom":20,"fontSize":18,"textAlign":"center","color":"#656656"},"container":{"padding":30,"marginTop":65,"alignItems":"center"}
+  }
+```  
 
 # Usage
 ```js

--- a/bin/react-native-css
+++ b/bin/react-native-css
@@ -11,42 +11,43 @@ var help = argv['h'] || argv['help'];
 var watch = argv['w'] || argv['watch'];
 var prettyPrint = argv['p'] || argv['pretty'] ? true : false;
 var inputOutput = (argv['i'] && argv['o']) || argv._[0] && argv._[1];
+var literalObject = argv['l'] || argv['literal'] ? true : false;
 
 if(inputOutput) {
-	var inputArgs = argv['i'] || argv._[0];
-	var outputArgs = argv['o'] || argv._[1];
+  var inputArgs = argv['i'] || argv._[0];
+  var outputArgs = argv['o'] || argv._[1];
 
-	var input = path.resolve(process.cwd(), inputArgs);
-	var output = path.resolve(process.cwd(), outputArgs);
+  var input = path.resolve(process.cwd(), inputArgs);
+  var output = path.resolve(process.cwd(), outputArgs);
 
-	css.parse(input, output, prettyPrint);
+  css.parse(input, output, prettyPrint, literalObject);
 
-	if(watch) {
-		console.log('Watching for changes on:'.green, inputArgs);
-		console.log('ctrl + c to exit'.red.underline);
+  if(watch) {
+    console.log('Watching for changes on:'.green, inputArgs);
+    console.log('ctrl + c to exit'.red.underline);
 
-		var watcher = chokidar.watch(input, {
-			ignored: /[\/\\]\./, persistent: true
-		}).on('change', function(path) {
-			console.log('File', inputArgs, 'has been changed'.green);
-			css.parse(input, output, prettyPrint);
-		});
-	}
+    var watcher = chokidar.watch(input, {
+      ignored: /[\/\\]\./, persistent: true
+    }).on('change', function(path) {
+      console.log('File', inputArgs, 'has been changed'.green);
+      css.parse(input, output, prettyPrint, literalObject);
+    });
+  }
 }else if(help ) {
-	message();
+  message();
 } else {
-	message();
+  message();
 }
 
 function message() {
-	console.log('version ' + pkgVersion);
-	console.log('example: react-native-css -i ../css/main.css -o ../styles/main.js -w '.blue);
-	console.log('example: react-native-css ../css/main.scss ../styles/main.js '.green);
+  console.log('version ' + pkgVersion);
+  console.log('example: react-native-css -i ../css/main.css -o ../styles/main.js -w '.blue);
+  console.log('example: react-native-css ../css/main.scss ../styles/main.js '.green);
 }
 
 require('request')('https://raw.githubusercontent.com/sabeurthabti/react-native-css/master/package.json', function (error, response, body) {
   if (!error && response.statusCode == 200) {
-		var version = JSON.parse(body).version;
-		if(version !== pkgVersion) console.log(`Running out-dated version ${pkgVersion}, please run 'npm update react-native-css'`.red)
+    var version = JSON.parse(body).version;
+    if(version !== pkgVersion) console.log(`Running out-dated version ${pkgVersion}, please run 'npm update react-native-css'`.red)
   }
 })

--- a/build/index.js
+++ b/build/index.js
@@ -29,12 +29,13 @@ var ReactNativeCss = (function () {
 
   _createClass(ReactNativeCss, [{
     key: 'parse',
-    value: function parse(input, output, prettyPrint, cb) {
+    value: function parse(input, output, prettyPrint, literalObject, cb) {
       if (output === undefined) output = './style.js';
+      if (prettyPrint === undefined) prettyPrint = false;
 
       var _this = this;
 
-      if (prettyPrint === undefined) prettyPrint = false;
+      if (literalObject === undefined) literalObject = false;
 
       if (_utilsJs2['default'].contains(input, /scss/)) {
         var _require$renderSync = require('node-sass').renderSync({
@@ -45,7 +46,7 @@ var ReactNativeCss = (function () {
         var css = _require$renderSync.css;
 
         var styleSheet = this.toJSS(css.toString());
-        _utilsJs2['default'].outputReactFriendlyStyle(styleSheet, output, prettyPrint);
+        _utilsJs2['default'].outputReactFriendlyStyle(styleSheet, output, prettyPrint, literalObject);
 
         if (cb) {
           cb(styleSheet);
@@ -57,7 +58,7 @@ var ReactNativeCss = (function () {
             process.exit();
           }
           var styleSheet = _this.toJSS(data);
-          _utilsJs2['default'].outputReactFriendlyStyle(styleSheet, output, prettyPrint);
+          _utilsJs2['default'].outputReactFriendlyStyle(styleSheet, output, prettyPrint, literalObject);
 
           if (cb) {
             cb(styleSheet);

--- a/build/utils.js
+++ b/build/utils.js
@@ -41,12 +41,13 @@ var Utils = (function () {
     }
   }, {
     key: "outputReactFriendlyStyle",
-    value: function outputReactFriendlyStyle(style, outputFile, prettyPrint) {
+    value: function outputReactFriendlyStyle(style, outputFile, prettyPrint, literalObject) {
       var indentation = prettyPrint ? 4 : 0;
-      var output = JSON.stringify(style, null, indentation);
-
+      var jsonOutput = JSON.stringify(style, null, indentation);
+      var output = "module.exports = ";
+      output += literalObject ? "" + jsonOutput : "require('react-native').StyleSheet.create(" + jsonOutput + ");";
       // Write to file
-      _fs2["default"].writeFileSync(outputFile, "module.exports = require('react-native').StyleSheet.create(" + output + ");");
+      _fs2["default"].writeFileSync(outputFile, output);
       return output;
     }
   }, {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export default class ReactNativeCss {
 
   }
 
-  parse(input, output = './style.js', prettyPrint = false, cb) {
+  parse(input, output = './style.js', prettyPrint = false, literalObject = false, cb) {
     if(utils.contains(input, /scss/)) {
 
       let {css} = require('node-sass').renderSync({
@@ -16,7 +16,7 @@ export default class ReactNativeCss {
       });
 
       let styleSheet = this.toJSS(css.toString());
-      utils.outputReactFriendlyStyle(styleSheet, output, prettyPrint);
+      utils.outputReactFriendlyStyle(styleSheet, output, prettyPrint, literalObject);
 
       if(cb) {
         cb(styleSheet);
@@ -29,7 +29,7 @@ export default class ReactNativeCss {
           process.exit();
         }
         let styleSheet = this.toJSS(data);
-        utils.outputReactFriendlyStyle(styleSheet, output, prettyPrint);
+        utils.outputReactFriendlyStyle(styleSheet, output, prettyPrint, literalObject);
 
         if(cb) {
           cb(styleSheet);

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,15 +19,13 @@ export default class Utils {
     fs.readFile(file, "utf8", cb);
   }
 
-  static outputReactFriendlyStyle(style, outputFile, prettyPrint) {
+  static outputReactFriendlyStyle(style, outputFile, prettyPrint, literalObject) {
     var indentation = prettyPrint ? 4 : 0;
-    var output = JSON.stringify(style, null, indentation);
-
-  	// Write to file
-  	fs.writeFileSync(
-		outputFile,
-		`module.exports = require('react-native').StyleSheet.create(${output});`
-	);
+    var jsonOutput = JSON.stringify(style, null, indentation);
+    var output = "module.exports = ";
+    output += (literalObject) ? `${jsonOutput}` : `require('react-native').StyleSheet.create(${jsonOutput});`;
+    // Write to file
+    fs.writeFileSync(outputFile, output);
     return output;
   }
 

--- a/test/fixtures/style-test.css
+++ b/test/fixtures/style-test.css
@@ -1,9 +1,9 @@
 .row {
-	top: 50px;
-	padding: 10px 10px 10px 5px;
-	flex-direction: row;
-	margin: 10px;
-	margin-bottom: 2px;
-	border-bottom-width: 5px;
+  top: 50px;
+  padding: 10px 10px 10px 5px;
+  flex-direction: row;
+  margin: 10px;
+  margin-bottom: 2px;
+  border-bottom-width: 5px;
   opacity: 0.6;
 }

--- a/test/rnc.test.js
+++ b/test/rnc.test.js
@@ -98,3 +98,11 @@ t.test("Regression test for issue #26", function(t) {
     t.end();
   });
 });
+
+t.test("Argument --literal generates a javascript literal object", function(t) {
+  css.parse('./test/fixtures/style-20.scss', './test/fixtures/style-test-literal.js', false, true, function(data) {
+    var styles = require('./fixtures/style-test-literal.js');
+    expect(styles.maincontainer.backgroundColor).toEqual("#F5FCFF");
+    t.end();
+  });
+});

--- a/test/rnc.test.js
+++ b/test/rnc.test.js
@@ -5,14 +5,14 @@ const css = new RNC();
 
 
 t.test("Parse CSS", function(t) {
-  css.parse('./test/fixtures/style.css', './test/fixtures/style.js', false, function(data) {
+  css.parse('./test/fixtures/style.css', './test/fixtures/style.js', false, false, function(data) {
     expect(data).toEqual({ main: { background: '#000' } })
     t.end();
   });
 });
 
 t.test("Parse SCSS", function(t) {
-  css.parse('./test/fixtures/style.scss', './test/fixtures/stylescss.js', false, function(data) {
+  css.parse('./test/fixtures/style.scss', './test/fixtures/stylescss.js', false, false, function(data) {
     expect(data).toEqual({ description:
       { flex: 102,
         marginLeft: 3,
@@ -34,7 +34,7 @@ t.test("Parse SCSS", function(t) {
       });
 
 t.test("Parse SCSS", function(t) {
-css.parse('./test/fixtures/style.scss', './test/fixtures/stylescss.js', false, function(data) {
+css.parse('./test/fixtures/style.scss', './test/fixtures/stylescss.js', false, false, function(data) {
   expect(data).toEqual({ description:
     { flex: 102,
       marginLeft: 3,
@@ -57,7 +57,7 @@ css.parse('./test/fixtures/style.scss', './test/fixtures/stylescss.js', false, f
 
 
 t.test("Parse SCSS error", function(t) {
-  css.parse('./test/fixtures/style-20.scss', './test/fixtures/stylescss-20.js', false, function(data) {
+  css.parse('./test/fixtures/style-20.scss', './test/fixtures/stylescss-20.js', false, false, function(data) {
     expect(data).toEqual({ maincontainer:
       { flex: 1,
         justifyContent: 'center',
@@ -69,7 +69,7 @@ t.test("Parse SCSS error", function(t) {
     });
 
     t.test("Parse SCSS error", function(t) {
-      css.parse('./test/fixtures/style-dorthwein.scss', './test/fixtures/stylescss-dorthwein.js', false, function(data) {
+      css.parse('./test/fixtures/style-dorthwein.scss', './test/fixtures/stylescss-dorthwein.js', false, false, function(data) {
         expect(data).toEqual({ center: { alignItems: 'center', alignSelf: 'center', justifyContent: 'center', textAlign: 'center' }, text: { color: '#000' } });
         t.end();
 
@@ -77,14 +77,14 @@ t.test("Parse SCSS error", function(t) {
       });
 
 t.test("Parse CSS and ignore unsupported property", function(t) {
-  css.parse('./test/fixtures/style-unsupported.scss', './test/fixtures/style-unsupported.js', false, function(data) {
+  css.parse('./test/fixtures/style-unsupported.scss', './test/fixtures/style-unsupported.js', false, false, function(data) {
     expect(data).toEqual({ container: { background: 'white' } })
     t.end();
   });
 });
 
 t.test("Parse CSS and turn properties into numbers", function(t) {
-  css.parse('./test/fixtures/style-number.scss', './test/fixtures/style-number.js', false, function(data) {
+  css.parse('./test/fixtures/style-number.scss', './test/fixtures/style-number.js', false, false, function(data) {
     expect(data).toEqual({ text:
       { fontSize: 12,
         width: 100 } })
@@ -93,8 +93,8 @@ t.test("Parse CSS and turn properties into numbers", function(t) {
 });
 
 t.test("Regression test for issue #26", function(t) {
-	css.parse('./test/fixtures/style-test.css', './test/fixtures/style-test.js', false, function(data) {
-		expect(data).toEqual({"row":{"top":50,"paddingTop":10,"paddingBottom":10,"paddingRight":10,"paddingLeft":5,"flexDirection":"row","marginTop":10,"marginLeft":10,"marginRight":10,"marginBottom":2,"borderBottomWidth":5,"opacity":0.6}});
-		t.end();
-	});
+  css.parse('./test/fixtures/style-test.css', './test/fixtures/style-test.js', false, false, function(data) {
+    expect(data).toEqual({"row":{"top":50,"paddingTop":10,"paddingBottom":10,"paddingRight":10,"paddingLeft":5,"flexDirection":"row","marginTop":10,"marginLeft":10,"marginRight":10,"marginBottom":2,"borderBottomWidth":5,"opacity":0.6}});
+    t.end();
+  });
 });


### PR DESCRIPTION
This pull request adds a boolean --literal argument, false by default.
When this argument is true, the `utils.outputReactFriendlyStyle` function will generate a javascript literal object instead of using the `Stylesheet.create` construct.  

Why a literal object ?  

From React docs: Stylesheet.create [is optional](https://facebook.github.io/react-native/docs/style.html#content) ...  

> StyleSheet.create construct is optional but provides some key advantages. It ensures that the values are immutable and opaque by transforming them into plain numbers that reference an internal table. By putting it at the end of the file, you also ensure that they are only created once for the application and not on every render.

Having a literal object has it's own advantages, for instance in components that use string props to change its style, we can still use the generated styles as string.  
```jsx
<NavigationIOS tintColor={styles.mainColor.color} />
```
But Stylesheet.create turns the object keys into numbers making it not accesible anymore.  
This pull request lets the user choose what construct they want for their styles.  
I hope you like it :) 