### PR TITLE
Fix value auto is set like null

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -181,7 +181,7 @@ var ReactNativeCss = (function () {
                   if (_utilsJs2['default'].arrayContains(property, numberize)) {
                     value = value.replace(/px|\s*/g, '');
 
-                    styles[(0, _toCamelCase2['default'])(property)] = parseFloat(value);
+                    styles[(0, _toCamelCase2['default'])(property)] = value === 'auto' ? value : parseFloat(value);
                   } else if (_utilsJs2['default'].arrayContains(property, changeArr)) {
                     baseDeclaration = {
                       type: 'description'
@@ -189,7 +189,7 @@ var ReactNativeCss = (function () {
                     values = value.replace(/px/g, '').split(/[\s,]+/);
 
                     values.forEach(function (value, index, arr) {
-                      arr[index] = parseInt(value);
+                      arr[index] = value === 'auto' ? value : parseInt(value);
                     });
 
                     length = values.length;
@@ -233,7 +233,7 @@ var ReactNativeCss = (function () {
                     }
                   } else {
                     if (!isNaN(declaration.value) && property !== 'font-weight') {
-                      declaration.value = parseFloat(declaration.value);
+                      declaration.value = declaration.value === 'auto' ? declaration.value : parseFloat(declaration.value);
                     }
 
                     styles[(0, _toCamelCase2['default'])(property)] = declaration.value;

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ export default class ReactNativeCss {
 
           if (utils.arrayContains(property, numberize)) {
             var value = value.replace(/px|\s*/g, '');
-            styles[toCamelCase(property)] = parseFloat(value);
+            styles[toCamelCase(property)] = value === 'auto' ? value : parseFloat(value);
           }
 
           else if (utils.arrayContains(property, changeArr)) {
@@ -139,7 +139,7 @@ export default class ReactNativeCss {
             var values = value.replace(/px/g, '').split(/[\s,]+/);
 
             values.forEach(function (value, index, arr) {
-              arr[index] = parseInt(value);
+              arr[index] = value === 'auto' ? value : parseInt(value);
             });
 
             var length = values.length;
@@ -179,7 +179,7 @@ export default class ReactNativeCss {
           }
           else {
             if (!isNaN(declaration.value) && property !== 'font-weight') {
-              declaration.value = parseFloat(declaration.value);
+              declaration.value = declaration.value === 'auto' ? declaration.value : parseFloat(declaration.value);
             }
 
             styles[toCamelCase(property)] = declaration.value;

--- a/test/auto.css
+++ b/test/auto.css
@@ -1,0 +1,5 @@
+teste {
+	height: auto;
+	width: auto;
+	margin: auto;
+}

--- a/test/auto.js
+++ b/test/auto.js
@@ -1,0 +1,7 @@
+module.exports = require('react-native').StyleSheet.create({
+    "teste": {
+        "height": "auto",
+        "width": "auto",
+        "margin": "auto"
+    }
+});


### PR DESCRIPTION
When I use the property with 'auto', it set like null, for example:

```css
img {
  width: 100%;
  height: auto;
}
```

Generate:
```css
"img":{"width":100,"height":null}
```

I compare the value, if the value is auto, I don't parse the value.

It's my first pull request, tell me if I can do it better.

Thanks