### PR TITLE
Add support for non-matching property names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,12 @@ export default class ReactNativeCss {
     // The list of supported properties is at https://facebook.github.io/react-native/docs/style.html#supported-properties
     const unsupported = ['display'];
 
+    const nonMatching = {
+        'flex-grow': 'flex',
+        'text-decoration': 'textDecorationLine',
+        'vertical-align': 'textVerticalAlign'
+    };
+
     let {stylesheet} = ParseCSS(utils.clean(stylesheetString));
 
     let JSONResult = {};
@@ -125,6 +131,15 @@ export default class ReactNativeCss {
           }
 
           if (utils.arrayContains(property, unsupported)) continue;
+
+          if (nonMatching[property]) {
+              rule.declarations.push({
+                property: nonMatching[property],
+                value: value,
+                type: 'declaration'
+              })
+              continue;
+          }
 
           if (utils.arrayContains(property, numberize)) {
             var value = value.replace(/px|\s*/g, '');

--- a/test/fixtures/style-non-matching.scss
+++ b/test/fixtures/style-non-matching.scss
@@ -1,0 +1,5 @@
+container {
+	flex-grow: unset;
+	text-decoration: none;
+	vertical-align: bottom;
+}

--- a/test/rnc.test.js
+++ b/test/rnc.test.js
@@ -107,3 +107,14 @@ t.test("Parse CSS and expand shorthand properties", function(t){
     t.end()
   });
 });
+
+t.test("Parse CSS and transform properties", function(t) {
+  css.parse('./test/fixtures/style-non-matching.scss', './test/fixtures/style-non-matching.js', false, false, function(data) {
+    expect(data).toEqual({ container: {
+        flex: 'unset',
+        textDecorationLine: 'none',
+    	textVerticalAlign: 'bottom'
+    } })
+    t.end();
+  });
+});


### PR DESCRIPTION
I'm adding support for text-decoration, flex-grow and vertical-align. This partially solves #47 